### PR TITLE
[BUGFIX] Use ember-d3 to include D3 as an ES2015 module

### DIFF
--- a/blueprints/ember-nvd3-shim/index.js
+++ b/blueprints/ember-nvd3-shim/index.js
@@ -4,10 +4,12 @@ module.exports = {
   normalizeEntityName: function() {},
 
   afterInstall: function() {
-    return this.addBowerPackagesToProject([
-      {name: 'nvd3', target: '^1.8.0'},
-      {name: 'd3', target: '^3.0.0'}
-    ]);
+    var self = this;
+
+    return this.addBowerPackageToProject('nvd3','^1.8.0')
+      .then(function () {
+        return self.addAddonToProject('brzpegasus/ember-d3#v3');
+      });
   }
 
   // locals: function(options) {


### PR DESCRIPTION
Resolves #35 as well as offirgolan/ember-cli-nvd3#10.